### PR TITLE
More README changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ This LLVM C backend has been resurrected by Julia Computing with various improve
 Installation instructions
 =========================
 
-This version of the LLVM C backend works with LLVM 10.0.
-
-Earlier versions are supported too (LLVM 7 and earlier should work).
+This version of the LLVM C backend supports LLVM 10. There is preliminary support for LLVM 11, and it should also work with LLVM 9 and 8.
 
 Step 1: Installing LLVM
 =======================
@@ -113,7 +111,7 @@ derivatives: `apt install libgtest-dev`).
 
 Other tests:
 
-First, compile llvm-cbe, and install pytest. Then:
+First, compile llvm-cbe, and install pytest (e.g. `pip install pytest`). Then:
 
 ```sh
     $ cd $HOME/llvm-project/llvm/projects/llvm-cbe
@@ -121,3 +119,5 @@ First, compile llvm-cbe, and install pytest. Then:
 ```
 
 You might have to adjust the llvm-cbe and lli paths in that configuration.
+
+If you want the tests to run faster, installing `pytest-xdist` will allow you to run the test suite in parallel, e.g. `pytest -n 4` if you want to use 4 cores.


### PR DESCRIPTION
* Make clearer and more specific LLVM support claims
* Mention parallel testing

I expect the LLVM part to be the controversial part. (https://github.com/JuliaComputingOSS/llvm-cbe/issues/60 is relevant of course.) The codebase supposedly supports many older versions of LLVM, but I assume only the newer ones are actually being tested. I also don't want to put just one version down, because that also doesn't reflect actual use or what the code says.