### PR TITLE
Fix all formatting and enforce formatting in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Check formatting
+        run: find . -iname '*.h' -o -iname '*.cpp' | xargs clang-format -Werror --dry-run --format=LLVM --verbose
+
       - name: Setup LLVM (Linux)
         if: ${{ runner.os == 'Linux' }}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,9 +27,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Check formatting
-        run: find . -iname '*.h' -o -iname '*.cpp' | xargs clang-format -Werror --dry-run --style=LLVM --verbose
-
       - name: Setup LLVM (Linux)
         if: ${{ runner.os == 'Linux' }}
         run: |
@@ -39,6 +36,7 @@ jobs:
           sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-16 160
           sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-16 160
           sudo update-alternatives --install /usr/bin/lli lli /usr/bin/lli-16 160
+          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-16 160
 
       - name: Setup LLVM and GCC (MacOS)
         if: ${{ runner.os == 'macOS' }}
@@ -70,6 +68,10 @@ jobs:
         run: |
           gcc --version
           pytest -n 16
+
+      - name: Check formatting
+        if: ${{ runner.os == 'Linux' }}
+        run: find . -iname '*.h' -o -iname '*.cpp' | xargs clang-format -Werror --dry-run --style=LLVM --verbose
 
   # The llvm-dev package doesn't exist for Windows, so we need to build LLVM ourselves.
   build-windows:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install pytest pytest-xdist
 
+      - name: Check formatting
+        if: ${{ runner.os == 'Linux' }}
+        run: find . -iname '*.h' -o -iname '*.cpp' | xargs clang-format -Werror --dry-run --style=LLVM --verbose
+
       - name: Build
         run: |
           mkdir build
@@ -68,10 +72,6 @@ jobs:
         run: |
           gcc --version
           pytest -n 16
-
-      - name: Check formatting
-        if: ${{ runner.os == 'Linux' }}
-        run: find . -iname '*.h' -o -iname '*.cpp' | xargs clang-format -Werror --dry-run --style=LLVM --verbose
 
   # The llvm-dev package doesn't exist for Windows, so we need to build LLVM ourselves.
   build-windows:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Check formatting
-        run: find . -iname '*.h' -o -iname '*.cpp' | xargs clang-format -Werror --dry-run --format=LLVM --verbose
+        run: find . -iname '*.h' -o -iname '*.cpp' | xargs clang-format -Werror --dry-run --style=LLVM --verbose
 
       - name: Setup LLVM (Linux)
         if: ${{ runner.os == 'Linux' }}

--- a/lib/Target/CBackend/CTargetMachine.h
+++ b/lib/Target/CBackend/CTargetMachine.h
@@ -32,14 +32,15 @@ class CTargetSubtargetInfo : public TargetSubtargetInfo {
 public:
 #if LLVM_VERSION_MAJOR >= 12
   CTargetSubtargetInfo(const TargetMachine &TM, const Triple &TT, StringRef CPU,
-                       StringRef TuneCPU,StringRef FS)
+                       StringRef TuneCPU, StringRef FS)
 #else
   CTargetSubtargetInfo(const TargetMachine &TM, const Triple &TT, StringRef CPU,
                        StringRef FS)
 #endif
 #if LLVM_VERSION_MAJOR >= 9
 #if LLVM_VERSION_MAJOR >= 12
-      : TargetSubtargetInfo(TT, CPU,TuneCPU, FS, ArrayRef<SubtargetFeatureKV>(),
+      : TargetSubtargetInfo(TT, CPU, TuneCPU, FS,
+                            ArrayRef<SubtargetFeatureKV>(),
                             ArrayRef<SubtargetSubTypeKV>(), nullptr, nullptr,
                             nullptr, nullptr, nullptr, nullptr),
 #else
@@ -67,11 +68,11 @@ public:
                  std::optional<Reloc::Model> RM,
                  std::optional<CodeModel::Model> CM,
 #else
-                 llvm:Optional<Reloc::Model> RM,
-                 llvm:Optional<CodeModel::Model> CM,
+                 llvm
+                 : Optional<Reloc::Model> RM, llvm
+                 : Optional<CodeModel::Model> CM,
 #endif
-                 CodeGenOpt::Level OL,
-                 bool /*JIT*/)
+                 CodeGenOpt::Level OL, bool /*JIT*/)
       : LLVMTargetMachine(T, "", TT, CPU, FS, Options,
 #if LLVM_VERSION_MAJOR >= 16
                           RM.value_or(Reloc::Static),
@@ -82,9 +83,11 @@ public:
 #endif
                           OL),
 #if LLVM_VERSION_MAJOR >= 12
-        SubtargetInfo(*this, TT, CPU,"", FS) {}
+        SubtargetInfo(*this, TT, CPU, "", FS) {
+  }
 #else
-        SubtargetInfo(*this, TT, CPU, FS) {}
+        SubtargetInfo(*this, TT, CPU, FS) {
+  }
 #endif
 
   /// Add passes to the specified pass manager to get the specified file

--- a/tools/llvm-cbe/llvm-cbe.cpp
+++ b/tools/llvm-cbe/llvm-cbe.cpp
@@ -274,8 +274,8 @@ static int compileModule(char **argv, LLVMContext &Context) {
 
 #if LLVM_VERSION_MAJOR > 10
   auto MAttrs = codegen::getMAttrs();
-  bool SkipModule =
-      codegen::getMCPU() == "help" || (!MAttrs.empty() && MAttrs.front() == "help");
+  bool SkipModule = codegen::getMCPU() == "help" ||
+                    (!MAttrs.empty() && MAttrs.front() == "help");
 #else
   bool SkipModule =
       MCPU == "help" || (!MAttrs.empty() && MAttrs.front() == "help");
@@ -304,7 +304,7 @@ static int compileModule(char **argv, LLVMContext &Context) {
   // Get the target specific parser.
   std::string Error;
   // Override MArch
-  //codegen::getMArch() = "c";
+  // codegen::getMArch() = "c";
   const std::string MArch = "c";
   const Target *TheTarget =
       TargetRegistry::lookupTarget(MArch, TheTriple, Error);
@@ -377,7 +377,8 @@ static int compileModule(char **argv, LLVMContext &Context) {
   // OwningPtr<targetMachine>
   std::unique_ptr<TargetMachine> target(TheTarget->createTargetMachine(
 #if LLVM_VERSION_MAJOR > 10
-      TheTriple.getTriple(), codegen::getMCPU(), FeaturesStr, Options, llvm::codegen::getRelocModel()));
+      TheTriple.getTriple(), codegen::getMCPU(), FeaturesStr, Options,
+      llvm::codegen::getRelocModel()));
 #else
       TheTriple.getTriple(), MCPU, FeaturesStr, Options, getRelocModel(),
       getCodeModel(), OLvl));
@@ -436,7 +437,8 @@ static int compileModule(char **argv, LLVMContext &Context) {
 #else
                                  FileType
 #endif
-                                 , NoVerify)) {
+                                     ,
+                                 NoVerify)) {
     errs() << argv[0] << ": target does not support generation of this"
            << " file type!\n";
     return 1;


### PR DESCRIPTION
* Fixed all formatting by running `clang-format`.
* Enforce code is formatted correctly by running `clang-format --Werror --dry-run` in CI.