### PR TITLE
Remove the rest if the `#if LLVM_VERSION_MAJOR` checks

### DIFF
--- a/lib/Target/CBackend/CTargetMachine.cpp
+++ b/lib/Target/CBackend/CTargetMachine.cpp
@@ -14,31 +14,18 @@
 #include "CTargetMachine.h"
 #include "CBackend.h"
 #include "llvm/CodeGen/TargetPassConfig.h"
-
-#if LLVM_VERSION_MAJOR >= 7
 #include "llvm/Transforms/Utils.h"
-#endif
 
 namespace llvm {
 
 bool CTargetMachine::addPassesToEmitFile(PassManagerBase &PM,
                                          raw_pwrite_stream &Out,
-#if LLVM_VERSION_MAJOR >= 7
                                          raw_pwrite_stream *DwoOut,
-#endif
                                          CodeGenFileType FileType,
                                          bool DisableVerify,
-#if LLVM_VERSION_MAJOR >= 10
                                          MachineModuleInfoWrapperPass *MMI) {
-#else
-                                         MachineModuleInfo *MMI) {
-#endif
 
-#if LLVM_VERSION_MAJOR >= 10
   if (FileType != CodeGenFileType::CGFT_AssemblyFile)
-#else
-  if (FileType != TargetMachine::CGFT_AssemblyFile)
-#endif
     return true;
 
   PM.add(new TargetPassConfig(*this, PM));
@@ -53,10 +40,8 @@ bool CTargetMachine::addPassesToEmitFile(PassManagerBase &PM,
   // Lower atomic operations to libcalls
   PM.add(createAtomicExpandPass());
 
-#if LLVM_VERSION_MAJOR >= 16
   // Lower vector operations into shuffle sequences
   PM.add(createExpandReductionsPass());
-#endif
 
   PM.add(new llvm_cbe::CWriter(Out));
   return false;

--- a/lib/Target/CBackend/CTargetMachine.h
+++ b/lib/Target/CBackend/CTargetMachine.h
@@ -30,30 +30,13 @@ public:
 
 class CTargetSubtargetInfo : public TargetSubtargetInfo {
 public:
-#if LLVM_VERSION_MAJOR >= 12
   CTargetSubtargetInfo(const TargetMachine &TM, const Triple &TT, StringRef CPU,
-                       StringRef TuneCPU,StringRef FS)
-#else
-  CTargetSubtargetInfo(const TargetMachine &TM, const Triple &TT, StringRef CPU,
-                       StringRef FS)
-#endif
-#if LLVM_VERSION_MAJOR >= 9
-#if LLVM_VERSION_MAJOR >= 12
-      : TargetSubtargetInfo(TT, CPU,TuneCPU, FS, ArrayRef<SubtargetFeatureKV>(),
+                       StringRef TuneCPU, StringRef FS)
+      : TargetSubtargetInfo(TT, CPU, TuneCPU, FS,
+                            ArrayRef<SubtargetFeatureKV>(),
                             ArrayRef<SubtargetSubTypeKV>(), nullptr, nullptr,
                             nullptr, nullptr, nullptr, nullptr),
-#else
-      : TargetSubtargetInfo(TT, CPU, FS, ArrayRef<SubtargetFeatureKV>(),
-                            ArrayRef<SubtargetSubTypeKV>(), nullptr, nullptr,
-                            nullptr, nullptr, nullptr, nullptr),
-#endif
-#else
-      : TargetSubtargetInfo(TT, CPU, FS, ArrayRef<SubtargetFeatureKV>(),
-                            ArrayRef<SubtargetFeatureKV>(), nullptr, nullptr,
-                            nullptr, nullptr, nullptr, nullptr, nullptr),
-#endif
-        Lowering(TM) {
-  }
+        Lowering(TM) {}
   bool enableAtomicExpand() const override;
   const TargetLowering *getTargetLowering() const override;
   const CTargetLowering Lowering;
@@ -62,44 +45,21 @@ public:
 class CTargetMachine : public LLVMTargetMachine {
 public:
   CTargetMachine(const Target &T, const Triple &TT, StringRef CPU, StringRef FS,
-                 const TargetOptions &Options,
-#if LLVM_VERSION_MAJOR >= 16
-                 std::optional<Reloc::Model> RM,
-                 std::optional<CodeModel::Model> CM,
-#else
-                 llvm:Optional<Reloc::Model> RM,
-                 llvm:Optional<CodeModel::Model> CM,
-#endif
-                 CodeGenOpt::Level OL,
+                 const TargetOptions &Options, std::optional<Reloc::Model> RM,
+                 std::optional<CodeModel::Model> CM, CodeGenOpt::Level OL,
                  bool /*JIT*/)
       : LLVMTargetMachine(T, "", TT, CPU, FS, Options,
-#if LLVM_VERSION_MAJOR >= 16
                           RM.value_or(Reloc::Static),
-                          CM.value_or(CodeModel::Small),
-#else
-                          RM.hasValue() ? RM.getValue() : Reloc::Static,
-                          CM.hasValue() ? CM.getValue() : CodeModel::Small,
-#endif
-                          OL),
-#if LLVM_VERSION_MAJOR >= 12
-        SubtargetInfo(*this, TT, CPU,"", FS) {}
-#else
-        SubtargetInfo(*this, TT, CPU, FS) {}
-#endif
+                          CM.value_or(CodeModel::Small), OL),
+        SubtargetInfo(*this, TT, CPU, "", FS) {}
 
   /// Add passes to the specified pass manager to get the specified file
   /// emitted.  Typically this will involve several steps of code generation.
-  bool addPassesToEmitFile(PassManagerBase &PM, raw_pwrite_stream &Out,
-#if LLVM_VERSION_MAJOR >= 7
-                           raw_pwrite_stream *DwoOut,
-#endif
-                           CodeGenFileType FileType, bool DisableVerify = true,
-#if LLVM_VERSION_MAJOR >= 10
-                           MachineModuleInfoWrapperPass *MMI = nullptr
-#else
-                           MachineModuleInfo *MMI = nullptr
-#endif
-                           ) override;
+  bool
+  addPassesToEmitFile(PassManagerBase &PM, raw_pwrite_stream &Out,
+                      raw_pwrite_stream *DwoOut, CodeGenFileType FileType,
+                      bool DisableVerify = true,
+                      MachineModuleInfoWrapperPass *MMI = nullptr) override;
 
   // TargetMachine interface
   const TargetSubtargetInfo *getSubtargetImpl(const Function &) const override;

--- a/lib/Target/CBackend/TargetInfo/CBackendTargetInfo.cpp
+++ b/lib/Target/CBackend/TargetInfo/CBackendTargetInfo.cpp
@@ -9,11 +9,8 @@
 
 #include "../CTargetMachine.h"
 #include "llvm/IR/Module.h"
-#if LLVM_VERSION_MAJOR >= 16
 #include "llvm/MC/TargetRegistry.h"
-#else
-#include "llvm/Support/TargetRegistry.h"
-#endif
+
 using namespace llvm;
 
 Target llvm::TheCBackendTarget;

--- a/lib/Target/CBackend/TopologicalSorter.cpp
+++ b/lib/Target/CBackend/TopologicalSorter.cpp
@@ -26,19 +26,10 @@ TopologicalSorter::TopologicalSorter(int Size) {
   Result.reserve(Size);
 }
 
-#if LLVM_VERSION_MAJOR >= 16
-std::optional<std::vector<int>>
-#else
-llvm::Optional<std::vector<int>>
-#endif
-TopologicalSorter::sort() {
+std::optional<std::vector<int>> TopologicalSorter::sort() {
   for (int I = 0; I < Size; ++I) {
     if (visit(I)) {
-#if LLVM_VERSION_MAJOR >= 16
       return std::nullopt;
-#else
-      return llvm::None;
-#endif
     }
   }
   return Result;

--- a/lib/Target/CBackend/TopologicalSorter.h
+++ b/lib/Target/CBackend/TopologicalSorter.h
@@ -15,11 +15,7 @@
 #define TOPOLOGICALSORTER_H
 
 #include <llvm/Config/llvm-config.h>
-#if LLVM_VERSION_MAJOR >= 16
 #include <optional>
-#else
-#include <llvm/ADT/Optional.h>
-#endif
 #include <vector>
 
 namespace llvm_cbe {
@@ -40,11 +36,7 @@ public:
   explicit TopologicalSorter(int Size);
 
   void addEdge(int Start, int End);
-#if LLVM_VERSION_MAJOR >= 16
   std::optional<std::vector<int>> sort(); // Returns None if there are cycles
-#else
-  llvm::Optional<std::vector<int>> sort(); // Returns None if there are cycles
-#endif
 };
 
 } // namespace llvm_cbe

--- a/tools/llvm-cbe/llvm-cbe.cpp
+++ b/tools/llvm-cbe/llvm-cbe.cpp
@@ -13,20 +13,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <llvm/Config/llvm-config.h>
-#if LLVM_VERSION_MAJOR >= 16
-#else
 #include "llvm/ADT/Triple.h"
-#endif
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/Analysis/TargetTransformInfo.h"
-#if LLVM_VERSION_MAJOR > 10
 #include "llvm/CodeGen/CommandFlags.h"
-#elif LLVM_VERSION_MAJOR >= 7
-#include "llvm/CodeGen/CommandFlags.inc"
-#else
-#include "llvm/CodeGen/CommandFlags.def"
-#endif
 #include "llvm/CodeGen/LinkAllAsmWriterComponents.h"
 #include "llvm/CodeGen/LinkAllCodegenComponents.h"
 #include "llvm/CodeGen/TargetPassConfig.h"
@@ -36,14 +26,11 @@
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IRReader/IRReader.h"
-#if LLVM_VERSION_MAJOR >= 16
-#include "llvm/MC/MCTargetOptionsCommandFlags.h"
-#endif
-#include "llvm/MC/SubtargetFeature.h"
-#include "llvm/Pass.h"
-#if LLVM_VERSION_MAJOR >= 10
 #include "llvm/InitializePasses.h"
-#endif
+#include "llvm/MC/MCTargetOptionsCommandFlags.h"
+#include "llvm/MC/SubtargetFeature.h"
+#include "llvm/MC/TargetRegistry.h"
+#include "llvm/Pass.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/FileSystem.h"
@@ -54,20 +41,14 @@
 #include "llvm/Support/PrettyStackTrace.h"
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/SourceMgr.h"
-#if LLVM_VERSION_MAJOR >= 16
-#include "llvm/MC/TargetRegistry.h"
-#else
-#include "llvm/Support/TargetRegistry.h"
-#endif
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/ToolOutputFile.h"
 #include "llvm/Target/TargetMachine.h"
+#include <llvm/Config/llvm-config.h>
 #include <memory>
 using namespace llvm;
 
-#if LLVM_VERSION_MAJOR > 10
 static codegen::RegisterCodeGenFlags CGF;
-#endif
 
 extern "C" void LLVMInitializeCBackendTarget();
 extern "C" void LLVMInitializeCBackendTargetInfo();
@@ -128,16 +109,8 @@ static ToolOutputFile *GetOutputStream(const char *TargetName,
     else {
       OutputFilename = GetFileNameRoot(InputFilename);
 
-#if LLVM_VERSION_MAJOR > 10
       switch (codegen::getFileType()) {
-#else
-      switch (FileType) {
-#endif
-#if LLVM_VERSION_MAJOR >= 10
       case CodeGenFileType::CGFT_AssemblyFile:
-#else
-      case TargetMachine::CGFT_AssemblyFile:
-#endif
         if (TargetName[0] == 'c') {
           if (TargetName[1] == 0)
             OutputFilename += ".cbe.c";
@@ -149,21 +122,13 @@ static ToolOutputFile *GetOutputStream(const char *TargetName,
           OutputFilename += ".s";
         break;
 
-#if LLVM_VERSION_MAJOR >= 10
       case CodeGenFileType::CGFT_ObjectFile:
-#else
-      case TargetMachine::CGFT_ObjectFile:
-#endif
         if (OS == Triple::Win32)
           OutputFilename += ".obj";
         else
           OutputFilename += ".o";
         break;
-#if LLVM_VERSION_MAJOR >= 10
       case CodeGenFileType::CGFT_Null:
-#else
-      case TargetMachine::CGFT_Null:
-#endif
         OutputFilename += ".null";
         break;
       }
@@ -172,41 +137,20 @@ static ToolOutputFile *GetOutputStream(const char *TargetName,
 
   // Decide if we need "binary" output.
   bool Binary = false;
-#if LLVM_VERSION_MAJOR > 10
   switch (codegen::getFileType()) {
-#else
-  switch (FileType) {
-#endif
-#if LLVM_VERSION_MAJOR >= 10
   case CodeGenFileType::CGFT_AssemblyFile:
-#else
-  case TargetMachine::CGFT_AssemblyFile:
-#endif
     break;
-#if LLVM_VERSION_MAJOR >= 10
   case CodeGenFileType::CGFT_ObjectFile:
   case CodeGenFileType::CGFT_Null:
-#else
-  case TargetMachine::CGFT_ObjectFile:
-  case TargetMachine::CGFT_Null:
-#endif
     Binary = true;
     break;
   }
 
   // Open the file.
   std::error_code error;
-#if LLVM_VERSION_MAJOR > 10
   sys::fs::OpenFlags OpenFlags = sys::fs::OF_None;
-#else
-  sys::fs::OpenFlags OpenFlags = sys::fs::F_None;
-#endif
   if (Binary)
-#if LLVM_VERSION_MAJOR > 10
     OpenFlags |= sys::fs::OF_Text;
-#else
-    OpenFlags |= sys::fs::F_Text;
-#endif
   ToolOutputFile *FDOut =
       new ToolOutputFile(OutputFilename.c_str(), error, OpenFlags);
   if (error) {
@@ -272,14 +216,9 @@ static int compileModule(char **argv, LLVMContext &Context) {
   Module *mod = 0;
   Triple TheTriple;
 
-#if LLVM_VERSION_MAJOR > 10
   auto MAttrs = codegen::getMAttrs();
-  bool SkipModule =
-      codegen::getMCPU() == "help" || (!MAttrs.empty() && MAttrs.front() == "help");
-#else
-  bool SkipModule =
-      MCPU == "help" || (!MAttrs.empty() && MAttrs.front() == "help");
-#endif
+  bool SkipModule = codegen::getMCPU() == "help" ||
+                    (!MAttrs.empty() && MAttrs.front() == "help");
 
   // If user just wants to list available options, skip module loading
   if (!SkipModule) {
@@ -304,7 +243,7 @@ static int compileModule(char **argv, LLVMContext &Context) {
   // Get the target specific parser.
   std::string Error;
   // Override MArch
-  //codegen::getMArch() = "c";
+  // codegen::getMArch() = "c";
   const std::string MArch = "c";
   const Target *TheTarget =
       TargetRegistry::lookupTarget(MArch, TheTriple, Error);
@@ -345,7 +284,6 @@ static int compileModule(char **argv, LLVMContext &Context) {
   }
 
   TargetOptions Options;
-#if LLVM_VERSION_MAJOR > 10
   Options.AllowFPOpFusion = codegen::getFuseFPOps();
   Options.UnsafeFPMath = codegen::getEnableUnsafeFPMath();
   Options.NoInfsFPMath = codegen::getEnableNoInfsFPMath();
@@ -356,32 +294,12 @@ static int compileModule(char **argv, LLVMContext &Context) {
     Options.FloatABIType = codegen::getFloatABIForCalls();
   Options.NoZerosInBSS = codegen::getDontPlaceZerosInBSS();
   Options.GuaranteedTailCallOpt = codegen::getEnableGuaranteedTailCallOpt();
-#if LLVM_VERSION_MAJOR < 12
-  Options.StackAlignmentOverride = codegen::getOverrideStackAlignment();
-#endif
-#else
-  Options.AllowFPOpFusion = FuseFPOps;
-  Options.UnsafeFPMath = EnableUnsafeFPMath;
-  Options.NoInfsFPMath = EnableNoInfsFPMath;
-  Options.NoNaNsFPMath = EnableNoNaNsFPMath;
-  Options.HonorSignDependentRoundingFPMathOption =
-      EnableHonorSignDependentRoundingFPMath;
-  if (FloatABIForCalls != FloatABI::Default)
-    Options.FloatABIType = FloatABIForCalls;
-  Options.NoZerosInBSS = DontPlaceZerosInBSS;
-  Options.GuaranteedTailCallOpt = EnableGuaranteedTailCallOpt;
-  Options.StackAlignmentOverride = OverrideStackAlignment;
-#endif
 
   // Jackson Korba 9/30/14
   // OwningPtr<targetMachine>
   std::unique_ptr<TargetMachine> target(TheTarget->createTargetMachine(
-#if LLVM_VERSION_MAJOR > 10
-      TheTriple.getTriple(), codegen::getMCPU(), FeaturesStr, Options, llvm::codegen::getRelocModel()));
-#else
-      TheTriple.getTriple(), MCPU, FeaturesStr, Options, getRelocModel(),
-      getCodeModel(), OLvl));
-#endif
+      TheTriple.getTriple(), codegen::getMCPU(), FeaturesStr, Options,
+      llvm::codegen::getRelocModel()));
   assert(target.get() && "Could not allocate target machine!");
   assert(mod && "Should have exited after outputting help!");
   TargetMachine &Target = *target.get();
@@ -412,31 +330,15 @@ static int compileModule(char **argv, LLVMContext &Context) {
   // Add intenal analysis passes from the target machine.
   PM.add(createTargetTransformInfoWrapperPass(Target.getTargetIRAnalysis()));
 
-#if LLVM_VERSION_MAJOR > 10
   if (mc::getExplicitRelaxAll()) {
     if (codegen::getFileType() != CodeGenFileType::CGFT_ObjectFile)
-#elif LLVM_VERSION_MAJOR == 10
-  if (RelaxAll) {
-    if (FileType != CodeGenFileType::CGFT_ObjectFile)
-#else
-  if (RelaxAll) {
-    if (FileType != TargetMachine::CGFT_ObjectFile)
-#endif
       errs() << argv[0]
              << ": warning: ignoring -mc-relax-all because filetype != obj\n";
   }
 
   // Ask the target to add backend passes as necessary.
-  if (Target.addPassesToEmitFile(PM, Out->os(),
-#if LLVM_VERSION_MAJOR >= 7
-                                 nullptr,
-#endif
-#if LLVM_VERSION_MAJOR > 10
-                                 codegen::getFileType()
-#else
-                                 FileType
-#endif
-                                 , NoVerify)) {
+  if (Target.addPassesToEmitFile(PM, Out->os(), nullptr, codegen::getFileType(),
+                                 NoVerify)) {
     errs() << argv[0] << ": target does not support generation of this"
            << " file type!\n";
     return 1;


### PR DESCRIPTION
The previous PR to only support LLVM 16 (#168) missed quite a few `#if LLVM_VERSION_MAJOR` declarations, so remove the rest of these (per discussion in #60).