### PR TITLE
Add support for all forms of getelementptr instruction

### DIFF
--- a/lib/Target/CBackend/CBackend.cpp
+++ b/lib/Target/CBackend/CBackend.cpp
@@ -1176,8 +1176,8 @@ void CWriter::printConstant(Constant *CPV, enum OperandContext Context) {
 
     case Instruction::GetElementPtr:
       Out << "(";
-      printGEPExpression(CE->getOperand(0), gep_type_begin(CPV),
-                         gep_type_end(CPV));
+      printGEPExpression(CE->getOperand(0), CPV->getNumOperands(),
+                         gep_type_begin(CPV), gep_type_end(CPV));
       Out << ")";
       return;
     case Instruction::Select:
@@ -1865,20 +1865,39 @@ void CWriter::writeOperandWithCast(Value *Operand, unsigned Opcode) {
   // Write out the casted operand if we should, otherwise just write the
   // operand.
 
-  // Extract the operand's type, we'll need it.
   bool shouldCast;
   bool castIsSigned;
   opcodeNeedsCast(Opcode, shouldCast, castIsSigned);
-
-  Type *OpTy = Operand->getType();
   if (shouldCast) {
     Out << "((";
-    printSimpleType(Out, OpTy, castIsSigned);
+    printSimpleType(Out, Operand->getType(), castIsSigned);
     Out << ")";
     writeOperand(Operand, ContextCasted);
     Out << ")";
   } else
     writeOperand(Operand, ContextCasted);
+}
+
+void CWriter::writeVectorOperandWithCast(Value *Operand, unsigned Index,
+                                         unsigned Opcode) {
+  // Write out the casted operand if we should, otherwise just write the
+  // operand.
+
+  bool shouldCast;
+  bool castIsSigned;
+  opcodeNeedsCast(Opcode, shouldCast, castIsSigned);
+  if (shouldCast) {
+    Out << "((";
+    printSimpleType(Out, cast<VectorType>(Operand->getType())->getElementType(),
+                    castIsSigned);
+    Out << ")";
+    writeOperand(Operand, ContextCasted);
+    Out << ".vector[" << Index << "])";
+  } else {
+    Out << "(";
+    writeOperand(Operand, ContextCasted);
+    Out << ".vector[" << Index << "])";
+  }
 }
 
 // Write the operand with a cast to another type based on the icmp predicate
@@ -5260,8 +5279,8 @@ void CWriter::visitAllocaInst(AllocaInst &I) {
   Out << "))";
 }
 
-void CWriter::printGEPExpression(Value *Ptr, gep_type_iterator I,
-                                 gep_type_iterator E) {
+void CWriter::printGEPExpression(Value *Ptr, unsigned NumOperands,
+                                 gep_type_iterator I, gep_type_iterator E) {
 
   // If there are no indices, just print out the pointer.
   if (I == E) {
@@ -5269,38 +5288,48 @@ void CWriter::printGEPExpression(Value *Ptr, gep_type_iterator I,
     return;
   }
 
-  Out << "(&";
+  Out << '(';
+  // Start with operand #2: First operand is the Ptr, and first indexing operand
+  // is special (thus it will print its own `&` if it needs it).
+  for (unsigned OperandIndex = 2; OperandIndex < NumOperands; ++OperandIndex) {
+    Out << "(&";
+  }
 
   // The first index of a GEP is special. It does pointer arithmetic without
   // indexing into the element type.
   Value *FirstOp = I.getOperand();
+  cwriter_assert(!FirstOp->getType()->isVectorTy());
   Type *IntoT = I.getIndexedType();
   ++I;
   if (!isConstantNull(FirstOp)) {
-    Out << "((";
+    Out << "(&((";
     printTypeName(Out, IntoT);
     Out << "*)";
     writeOperand(Ptr);
     Out << ")[";
     writeOperandWithCast(FirstOp, Instruction::GetElementPtr);
-    Out << ']';
+    Out << "])";
   } else {
     // When the first index is 0 (very common) we can simplify it.
     if (tryGetTypeOfAddressExposedValue(Ptr)) {
       // Print P rather than (&P)[0]
+      Out << "(&";
       writeOperandInternal(Ptr);
+      Out << ')';
     } else if (I != E && I.isStruct()) {
       // If the second index is a struct index, print P->f instead of P[0].f
-      Out << "((";
+      Out << "(&((";
       printTypeName(Out, I.getStructType());
       Out << "*)";
       writeOperand(Ptr);
-      Out << ")->field" << cast<ConstantInt>(I.getOperand())->getZExtValue();
+      Out << ")->field" << cast<ConstantInt>(I.getOperand())->getZExtValue()
+          << ')';
       // Eat the struct index
       ++I;
+      Out << ')';
     } else {
       // Print (*P)[1] instead of P[0][1] (more idiomatic)
-      Out << "(*((";
+      Out << "((";
       if (isEmptyType(IntoT)) {
         if (VectorType *VT = dyn_cast<VectorType>(IntoT)) {
           printTypeName(Out, VT->getElementType());
@@ -5314,7 +5343,7 @@ void CWriter::printGEPExpression(Value *Ptr, gep_type_iterator I,
       }
       Out << "*)";
       writeOperand(Ptr);
-      Out << "))";
+      Out << ")";
     }
   }
 
@@ -5327,43 +5356,21 @@ void CWriter::printGEPExpression(Value *Ptr, gep_type_iterator I,
                               // but we don't support it here
 
     if (I.isStruct()) {
-      Out << ".field" << cast<ConstantInt>(Opnd)->getZExtValue();
-    } else if (IntoT->isArrayTy()) {
-      // Zero-element array types are either skipped or, for pointers, peeled
-      // off by skipEmptyArrayTypes. In this latter case, we can translate
-      // zero-element array indexing as pointer arithmetic.
-      if (IntoT->getArrayNumElements() == 0) {
-        if (!isConstantNull(Opnd)) {
-          // TODO: The operator precedence here is only correct if there are no
-          //       subsequent indexable types other than zero-element arrays.
-          cwriter_assert(skipEmptyArrayTypes(IntoT)->isSingleValueType());
-          Out << " + (";
-          writeOperandWithCast(Opnd, Instruction::GetElementPtr);
-          Out << ')';
-        }
-      } else {
-        Out << ".array[";
-        writeOperandWithCast(Opnd, Instruction::GetElementPtr);
-        Out << ']';
-      }
-    } else if (!IntoT->isVectorTy()) {
-      Out << '[';
+      Out << "->field" << cast<ConstantInt>(Opnd)->getZExtValue();
+    } else if (IntoT->isArrayTy() && IntoT->getArrayNumElements() > 0) {
+      Out << "->array[";
       writeOperandWithCast(Opnd, Instruction::GetElementPtr);
       Out << ']';
     } else {
-      // If the last index is into a vector, then print it out as "+j)".
-      if (!isConstantNull(Opnd)) {
-        Out << "))"; // avoid "+0".
-      } else {
-        Out << ")+(";
-        writeOperandWithCast(I.getOperand(), Instruction::GetElementPtr);
-        Out << "))";
-      }
+      Out << '[';
+      writeOperandWithCast(Opnd, Instruction::GetElementPtr);
+      Out << ']';
     }
 
     IntoT = I.getIndexedType();
+    Out << ')';
   }
-  Out << ")";
+  Out << ')';
 }
 
 void CWriter::writeMemoryAccess(Value *Operand, Type *OperandType,
@@ -5465,7 +5472,36 @@ void CWriter::visitFenceInst(FenceInst &I) {
 void CWriter::visitGetElementPtrInst(GetElementPtrInst &I) {
   CurInstr = &I;
 
-  printGEPExpression(I.getPointerOperand(), gep_type_begin(I), gep_type_end(I));
+  // GetElementPtrInst has a special form that takes a vector as the only index
+  // operand and then returns a vector of pointers into the pointer operand.
+  auto FirstOp = gep_type_begin(I);
+  if ((FirstOp != gep_type_end(I)) &&
+      isa<VectorType>(FirstOp.getOperand()->getType())) {
+    CtorDeclTypes.insert(I.getType());
+    Out << "llvm_ctor_";
+    printTypeString(Out, I.getType(), false);
+    Out << "(";
+    for (unsigned Index = 0;
+         Index < NumberOfElements(cast<VectorType>(I.getType())); ++Index) {
+      if (Index > 0)
+        Out << ", ";
+      Out << "(&((";
+      printTypeName(Out, FirstOp.getIndexedType());
+      Out << "*)";
+      writeOperand(I.getPointerOperand());
+      Out << ")[";
+      writeVectorOperandWithCast(FirstOp.getOperand(), Index,
+                                 Instruction::GetElementPtr);
+      Out << "])";
+    }
+    Out << ")";
+
+    // If using a vector, then only one op is allowed.
+    cwriter_assert(++FirstOp == gep_type_end(I));
+  } else {
+    printGEPExpression(I.getPointerOperand(), I.getNumOperands(),
+                       gep_type_begin(I), gep_type_end(I));
+  }
 }
 
 void CWriter::visitVAArgInst(VAArgInst &I) {

--- a/lib/Target/CBackend/CBackend.cpp
+++ b/lib/Target/CBackend/CBackend.cpp
@@ -5318,7 +5318,7 @@ void CWriter::printGEPExpression(Value *Ptr, unsigned NumOperands,
       Out << ')';
     } else if (I != E && I.isStruct()) {
       // If the second index is a struct index, print P->f instead of P[0].f
-      Out << "(&((";
+      Out << "(((";
       printTypeName(Out, I.getStructType());
       Out << "*)";
       writeOperand(Ptr);
@@ -5485,7 +5485,7 @@ void CWriter::visitGetElementPtrInst(GetElementPtrInst &I) {
          Index < NumberOfElements(cast<VectorType>(I.getType())); ++Index) {
       if (Index > 0)
         Out << ", ";
-      Out << "(&((";
+      Out << "&(((";
       printTypeName(Out, FirstOp.getIndexedType());
       Out << "*)";
       writeOperand(I.getPointerOperand());

--- a/lib/Target/CBackend/CBackend.h
+++ b/lib/Target/CBackend/CBackend.h
@@ -231,6 +231,8 @@ private:
   void writeOperandInternal(Value *Operand,
                             enum OperandContext Context = ContextNormal);
   void writeOperandWithCast(Value *Operand, unsigned Opcode);
+  void writeVectorOperandWithCast(Value *Operand, unsigned Index,
+                                  unsigned Opcode);
   void opcodeNeedsCast(unsigned Opcode, bool &shouldCast, bool &castIsSigned);
 
   void writeOperandWithCast(Value *Operand, ICmpInst &I);
@@ -328,7 +330,8 @@ private:
                                   unsigned Indent);
   void printBranchToBlock(BasicBlock *CurBlock, BasicBlock *SuccBlock,
                           unsigned Indent);
-  void printGEPExpression(Value *Ptr, gep_type_iterator I, gep_type_iterator E);
+  void printGEPExpression(Value *Ptr, unsigned NumOperands, gep_type_iterator I,
+                          gep_type_iterator E);
 
   std::string GetValueName(const Value *Operand);
 

--- a/test/ll_tests/test_empty_array_geps_struct.ll
+++ b/test/ll_tests/test_empty_array_geps_struct.ll
@@ -1,0 +1,34 @@
+; This tests GEPs and Phi nodes for pointers to zero-sized arrays of structs.
+
+%struct.intbox = type { i32 }
+
+@correctConstant = constant [3 x %struct.intbox] [%struct.intbox { i32 1 }, %struct.intbox { i32 2 }, %struct.intbox { i32 3 }]
+@wrongConstant = constant [5 x %struct.intbox] [%struct.intbox { i32 4 }, %struct.intbox { i32 5 }, %struct.intbox { i32 6 }, %struct.intbox { i32 7 }, %struct.intbox { i32 8 }]
+
+define i32 @main(i32 %argc, i8** %argv) {
+bb0:
+  %alwaysTrue = icmp eq i32 %argc, 1
+  br i1 %alwaysTrue, label %iftrue, label %iffalse
+
+iftrue:
+  br label %end
+
+iffalse:
+  br label %end
+
+end:
+  %theConstant = phi [0 x %struct.intbox]* [ bitcast ([3 x %struct.intbox]* @correctConstant to [0 x %struct.intbox]*), %iftrue ], [ bitcast ([5 x %struct.intbox]* @wrongConstant to [0 x %struct.intbox]*), %iffalse ]
+
+  %int1ptr = getelementptr [0 x %struct.intbox], [0 x %struct.intbox]* %theConstant, i64 0, i64 0, i32 0
+  %int2ptr = getelementptr [0 x %struct.intbox], [0 x %struct.intbox]* %theConstant, i64 0, i64 1, i32 0
+  %int3ptr = getelementptr [0 x %struct.intbox], [0 x %struct.intbox]* %theConstant, i64 0, i64 2, i32 0
+
+  %int1 = load i32, i32* %int1ptr, align 4
+  %int2 = load i32, i32* %int2ptr, align 4
+  %int3 = load i32, i32* %int3ptr, align 4
+
+  %sum12 = add i32 %int1, %int2
+  %res = add i32 %sum12, %int3
+
+  ret i32 %res
+}

--- a/test/ll_tests/test_gep_index_vec.ll
+++ b/test/ll_tests/test_gep_index_vec.ll
@@ -1,0 +1,35 @@
+; This tests GEPs being indexed via vectors.
+
+@correctStringConstant = constant [3 x i8] c"\01\02\03"
+@wrongStringConstant = constant [3 x i8] c"\04\05\06"
+
+define i32 @main(i32 %argc, i8** %argv) {
+bb0:
+  %alwaysTrue = icmp eq i32 %argc, 1
+  br i1 %alwaysTrue, label %iftrue, label %iffalse
+
+iftrue:
+  br label %end
+
+iffalse:
+  br label %end
+
+end:
+  %stringConstant = phi ptr [ @correctStringConstant, %iftrue ], [ @wrongStringConstant, %iffalse ]
+
+  %charPtrVec = getelementptr i8, ptr %stringConstant, <3 x i64> <i64 0, i64 1, i64 2>
+
+  %char1ptr = extractelement <3 x ptr> %charPtrVec, i64 0
+  %char2ptr = extractelement <3 x ptr> %charPtrVec, i64 1
+  %char3ptr = extractelement <3 x ptr> %charPtrVec, i64 2
+
+  %char1 = load i8, i8* %char1ptr
+  %char2 = load i8, i8* %char2ptr
+  %char3 = load i8, i8* %char3ptr
+
+  %sum12 = add i8 %char1, %char2
+  %sum = add i8 %sum12, %char3
+  %res = zext i8 %sum to i32
+
+  ret i32 %res
+}


### PR DESCRIPTION
Current support for the `getelementptr` instruction had two restrictions:
* No support for the vector-index form (https://llvm.org/docs/LangRef.html#vector-of-pointers).
* When indexing into a 0-sized array, if there were any subsequent indexes then the generated code would be incorrect (due to operator precedence).

This change removes these restrictions:
* Detect the vector-index form and generate a vector of pointers.
* Simplify and unify how indexes-after-the-first are generated to avoid the operator precedence issue.
* At each step of indexing, always take the address of the expression - this allows uniform chaining of indexing (we can always assume the receiver is a pointer) and no special casing for the outermost expression (as we need to return a pointer).
* Added tests for missing scenarios.