### PR TITLE
Fix "add with overflow" intrinsic, remove maximum and minimum intrinsic

### DIFF
--- a/lib/Target/CBackend/CBackend.cpp
+++ b/lib/Target/CBackend/CBackend.cpp
@@ -4515,8 +4515,6 @@ void CWriter::printIntrinsicDefinition(FunctionType *funT, unsigned Opcode,
       errorWithMessage("unsupported instrinsic");
 
     case Intrinsic::uadd_with_overflow:
-      //   r.field0 = a + b;
-      //   r.field1 = (r.field0 < a);
       cwriter_assert(cast<StructType>(retT)->getElementType(0) == elemT);
       Out << "  r.field0 = a + b;\n";
       Out << "  r.field1 = (r.field0 < a);\n";
@@ -5025,8 +5023,6 @@ bool CWriter::visitBuiltinCall(CallInst &I, Intrinsic::ID ID) {
   case Intrinsic::rint:
   case Intrinsic::sqrt:
   case Intrinsic::trunc:
-  case Intrinsic::maxnum:
-  case Intrinsic::minnum:
     headerUseMath();
     return false;
   case Intrinsic::uadd_with_overflow:

--- a/test/ll_tests/test_intrinsic_sadd_with_overflow.ll
+++ b/test/ll_tests/test_intrinsic_sadd_with_overflow.ll
@@ -1,0 +1,86 @@
+declare {i8, i1} @llvm.sadd.with.overflow.i8(i8 %a, i8 %b)
+declare {i16, i1} @llvm.sadd.with.overflow.i16(i16 %a, i16 %b)
+declare {i32, i1} @llvm.sadd.with.overflow.i32(i32 %a, i32 %b)
+declare {i64, i1} @llvm.sadd.with.overflow.i64(i64 %a, i64 %b)
+
+; Function Attrs: noinline nounwind optnone uwtable
+define dso_local i32 @main() #0 {
+basic_8:
+  %basic_8_res = call { i8, i1 } @llvm.sadd.with.overflow.i8(i8 52, i8 -10)
+  %basic_8_sum = extractvalue { i8, i1 } %basic_8_res, 0
+  %basic_8_sum_ok = icmp eq i8 %basic_8_sum, 42
+  br i1 %basic_8_sum_ok, label %basic_8_overflow_check, label %error
+
+basic_8_overflow_check:
+  %basic_8_overflowed = extractvalue { i8, i1 } %basic_8_res, 1
+  br i1 %basic_8_overflowed, label %error, label %overflowing_8
+
+overflowing_8:
+  %overflowing_8_res = call { i8, i1 } @llvm.sadd.with.overflow.i8(i8 u0x7C, i8 u0x7C)
+  %overflowing_8_overflowed = extractvalue { i8, i1 } %overflowing_8_res, 1
+  br i1 %overflowing_8_overflowed, label %basic_16, label %error
+
+basic_16:
+  %basic_16_res = call { i16, i1 } @llvm.sadd.with.overflow.i16(i16 52, i16 -10)
+  %basic_16_sum = extractvalue { i16, i1 } %basic_16_res, 0
+  %basic_16_sum_ok = icmp eq i16 %basic_16_sum, 42
+  br i1 %basic_16_sum_ok, label %basic_16_overflow_check, label %error
+
+basic_16_overflow_check:
+  %basic_16_overflowed = extractvalue { i16, i1 } %basic_16_res, 1
+  br i1 %basic_16_overflowed, label %error, label %overflowing_16
+
+overflowing_16:
+  %overflowing_16_res = call { i16, i1 } @llvm.sadd.with.overflow.i16(i16 u0x7CCC, i16 u0x7CCC)
+  %overflowing_16_overflowed = extractvalue { i16, i1 } %overflowing_16_res, 1
+  br i1 %overflowing_16_overflowed, label %basic_32, label %error
+
+basic_32:
+  %basic_32_res = call { i32, i1 } @llvm.sadd.with.overflow.i32(i32 52, i32 -10)
+  %basic_32_sum = extractvalue { i32, i1 } %basic_32_res, 0
+  %basic_32_sum_ok = icmp eq i32 %basic_32_sum, 42
+  br i1 %basic_32_sum_ok, label %basic_32_overflow_check, label %error
+
+basic_32_overflow_check:
+  %basic_32_overflowed = extractvalue { i32, i1 } %basic_32_res, 1
+  br i1 %basic_32_overflowed, label %error, label %overflowing_32
+
+overflowing_32:
+  %overflowing_32_res = call { i32, i1 } @llvm.sadd.with.overflow.i32(i32 u0x7CCCCCCC, i32 u0x7CCCCCCC)
+  %overflowing_32_overflowed = extractvalue { i32, i1 } %overflowing_32_res, 1
+  br i1 %overflowing_32_overflowed, label %basic_64, label %error
+
+basic_64:
+  %basic_64_res = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 52, i64 -10)
+  %basic_64_sum = extractvalue { i64, i1 } %basic_64_res, 0
+  %basic_64_sum_ok = icmp eq i64 %basic_64_sum, 42
+  br i1 %basic_64_sum_ok, label %basic_64_overflow_check, label %error
+
+basic_64_overflow_check:
+  %basic_64_overflowed = extractvalue { i64, i1 } %basic_64_res, 1
+  br i1 %basic_64_overflowed, label %error, label %overflowing_64
+
+overflowing_64:
+  %overflowing_64_res = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 u0x7CCCCCCCCCCCCCCC, i64 u0x7CCCCCCCCCCCCCCC)
+  %overflowing_64_overflowed = extractvalue { i64, i1 } %overflowing_64_res, 1
+  br i1 %overflowing_64_overflowed, label %ok, label %error
+
+ok:
+  ret i32 6
+
+error:
+  %retVal = phi i32
+    [ 81, %basic_8 ],
+    [ 82, %basic_8_overflow_check ],
+    [ 83, %overflowing_8 ],
+    [ 161, %basic_16 ],
+    [ 162, %basic_16_overflow_check ],
+    [ 163, %overflowing_16 ],
+    [ 321, %basic_32 ],
+    [ 322, %basic_32_overflow_check ],
+    [ 323, %overflowing_32 ],
+    [ 641, %basic_64 ],
+    [ 642, %basic_64_overflow_check ],
+    [ 643, %overflowing_64 ]
+  ret i32 %retVal
+}

--- a/test/ll_tests/test_intrinsic_sadd_with_overflow.ll
+++ b/test/ll_tests/test_intrinsic_sadd_with_overflow.ll
@@ -18,7 +18,12 @@ basic_8_overflow_check:
 overflowing_8:
   %overflowing_8_res = call { i8, i1 } @llvm.sadd.with.overflow.i8(i8 u0x7C, i8 u0x7C)
   %overflowing_8_overflowed = extractvalue { i8, i1 } %overflowing_8_res, 1
-  br i1 %overflowing_8_overflowed, label %basic_16, label %error
+  br i1 %overflowing_8_overflowed, label %underflowing_8, label %error
+
+underflowing_8:
+  %underflowing_8_res = call { i8, i1 } @llvm.sadd.with.overflow.i8(i8 u0x8C, i8 u0x8C)
+  %underflowing_8_overflowed = extractvalue { i8, i1 } %underflowing_8_res, 1
+  br i1 %underflowing_8_overflowed, label %basic_16, label %error
 
 basic_16:
   %basic_16_res = call { i16, i1 } @llvm.sadd.with.overflow.i16(i16 52, i16 -10)
@@ -33,7 +38,12 @@ basic_16_overflow_check:
 overflowing_16:
   %overflowing_16_res = call { i16, i1 } @llvm.sadd.with.overflow.i16(i16 u0x7CCC, i16 u0x7CCC)
   %overflowing_16_overflowed = extractvalue { i16, i1 } %overflowing_16_res, 1
-  br i1 %overflowing_16_overflowed, label %basic_32, label %error
+  br i1 %overflowing_16_overflowed, label %underflowing_16, label %error
+
+underflowing_16:
+  %underflowing_16_res = call { i16, i1 } @llvm.sadd.with.overflow.i16(i16 u0x8CCC, i16 u0x8CCC)
+  %underflowing_16_overflowed = extractvalue { i16, i1 } %underflowing_16_res, 1
+  br i1 %underflowing_16_overflowed, label %basic_32, label %error
 
 basic_32:
   %basic_32_res = call { i32, i1 } @llvm.sadd.with.overflow.i32(i32 52, i32 -10)
@@ -48,7 +58,12 @@ basic_32_overflow_check:
 overflowing_32:
   %overflowing_32_res = call { i32, i1 } @llvm.sadd.with.overflow.i32(i32 u0x7CCCCCCC, i32 u0x7CCCCCCC)
   %overflowing_32_overflowed = extractvalue { i32, i1 } %overflowing_32_res, 1
-  br i1 %overflowing_32_overflowed, label %basic_64, label %error
+  br i1 %overflowing_32_overflowed, label %underflowing_32, label %error
+
+underflowing_32:
+  %underflowing_32_res = call { i32, i1 } @llvm.sadd.with.overflow.i32(i32 u0x8CCCCCCC, i32 u0x8CCCCCCC)
+  %underflowing_32_overflowed = extractvalue { i32, i1 } %underflowing_32_res, 1
+  br i1 %underflowing_32_overflowed, label %basic_64, label %error
 
 basic_64:
   %basic_64_res = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 52, i64 -10)
@@ -63,7 +78,12 @@ basic_64_overflow_check:
 overflowing_64:
   %overflowing_64_res = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 u0x7CCCCCCCCCCCCCCC, i64 u0x7CCCCCCCCCCCCCCC)
   %overflowing_64_overflowed = extractvalue { i64, i1 } %overflowing_64_res, 1
-  br i1 %overflowing_64_overflowed, label %ok, label %error
+  br i1 %overflowing_64_overflowed, label %underflowing_64, label %error
+
+underflowing_64:
+  %underflowing_64_res = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 u0x8CCCCCCCCCCCCCCC, i64 u0x8CCCCCCCCCCCCCCC)
+  %underflowing_64_overflowed = extractvalue { i64, i1 } %underflowing_64_res, 1
+  br i1 %underflowing_64_overflowed, label %ok, label %error
 
 ok:
   ret i32 6
@@ -73,14 +93,18 @@ error:
     [ 81, %basic_8 ],
     [ 82, %basic_8_overflow_check ],
     [ 83, %overflowing_8 ],
+    [ 84, %underflowing_8 ],
     [ 161, %basic_16 ],
     [ 162, %basic_16_overflow_check ],
     [ 163, %overflowing_16 ],
+    [ 164, %underflowing_16 ],
     [ 321, %basic_32 ],
     [ 322, %basic_32_overflow_check ],
     [ 323, %overflowing_32 ],
+    [ 324, %underflowing_32 ],
     [ 641, %basic_64 ],
     [ 642, %basic_64_overflow_check ],
-    [ 643, %overflowing_64 ]
+    [ 643, %overflowing_64 ],
+    [ 644, %underflowing_64 ]
   ret i32 %retVal
 }

--- a/test/ll_tests/test_intrinsic_uadd_with_overflow.ll
+++ b/test/ll_tests/test_intrinsic_uadd_with_overflow.ll
@@ -1,0 +1,86 @@
+declare {i8, i1} @llvm.uadd.with.overflow.i8(i8 %a, i8 %b)
+declare {i16, i1} @llvm.uadd.with.overflow.i16(i16 %a, i16 %b)
+declare {i32, i1} @llvm.uadd.with.overflow.i32(i32 %a, i32 %b)
+declare {i64, i1} @llvm.uadd.with.overflow.i64(i64 %a, i64 %b)
+
+; Function Attrs: noinline nounwind optnone uwtable
+define dso_local i32 @main() #0 {
+basic_8:
+  %basic_8_res = call { i8, i1 } @llvm.uadd.with.overflow.i8(i8 12, i8 30)
+  %basic_8_sum = extractvalue { i8, i1 } %basic_8_res, 0
+  %basic_8_sum_ok = icmp eq i8 %basic_8_sum, 42
+  br i1 %basic_8_sum_ok, label %basic_8_overflow_check, label %error
+
+basic_8_overflow_check:
+  %basic_8_overflowed = extractvalue { i8, i1 } %basic_8_res, 1
+  br i1 %basic_8_overflowed, label %error, label %overflowing_8
+
+overflowing_8:
+  %overflowing_8_res = call { i8, i1 } @llvm.uadd.with.overflow.i8(i8 u0xCC, i8 u0xCC)
+  %overflowing_8_overflowed = extractvalue { i8, i1 } %overflowing_8_res, 1
+  br i1 %overflowing_8_overflowed, label %basic_16, label %error
+
+basic_16:
+  %basic_16_res = call { i16, i1 } @llvm.uadd.with.overflow.i16(i16 12, i16 30)
+  %basic_16_sum = extractvalue { i16, i1 } %basic_16_res, 0
+  %basic_16_sum_ok = icmp eq i16 %basic_16_sum, 42
+  br i1 %basic_16_sum_ok, label %basic_16_overflow_check, label %error
+
+basic_16_overflow_check:
+  %basic_16_overflowed = extractvalue { i16, i1 } %basic_16_res, 1
+  br i1 %basic_16_overflowed, label %error, label %overflowing_16
+
+overflowing_16:
+  %overflowing_16_res = call { i16, i1 } @llvm.uadd.with.overflow.i16(i16 u0xCCCC, i16 u0xCCCC)
+  %overflowing_16_overflowed = extractvalue { i16, i1 } %overflowing_16_res, 1
+  br i1 %overflowing_16_overflowed, label %basic_32, label %error
+
+basic_32:
+  %basic_32_res = call { i32, i1 } @llvm.uadd.with.overflow.i32(i32 12, i32 30)
+  %basic_32_sum = extractvalue { i32, i1 } %basic_32_res, 0
+  %basic_32_sum_ok = icmp eq i32 %basic_32_sum, 42
+  br i1 %basic_32_sum_ok, label %basic_32_overflow_check, label %error
+
+basic_32_overflow_check:
+  %basic_32_overflowed = extractvalue { i32, i1 } %basic_32_res, 1
+  br i1 %basic_32_overflowed, label %error, label %overflowing_32
+
+overflowing_32:
+  %overflowing_32_res = call { i32, i1 } @llvm.uadd.with.overflow.i32(i32 u0xCCCCCCCC, i32 u0xCCCCCCCC)
+  %overflowing_32_overflowed = extractvalue { i32, i1 } %overflowing_32_res, 1
+  br i1 %overflowing_32_overflowed, label %basic_64, label %error
+
+basic_64:
+  %basic_64_res = call { i64, i1 } @llvm.uadd.with.overflow.i64(i64 12, i64 30)
+  %basic_64_sum = extractvalue { i64, i1 } %basic_64_res, 0
+  %basic_64_sum_ok = icmp eq i64 %basic_64_sum, 42
+  br i1 %basic_64_sum_ok, label %basic_64_overflow_check, label %error
+
+basic_64_overflow_check:
+  %basic_64_overflowed = extractvalue { i64, i1 } %basic_64_res, 1
+  br i1 %basic_64_overflowed, label %error, label %overflowing_64
+
+overflowing_64:
+  %overflowing_64_res = call { i64, i1 } @llvm.uadd.with.overflow.i64(i64 u0xCCCCCCCCCCCCCCCC, i64 u0xCCCCCCCCCCCCCCCC)
+  %overflowing_64_overflowed = extractvalue { i64, i1 } %overflowing_64_res, 1
+  br i1 %overflowing_64_overflowed, label %ok, label %error
+
+ok:
+  ret i32 6
+
+error:
+  %retVal = phi i32
+    [ 81, %basic_8 ],
+    [ 82, %basic_8_overflow_check ],
+    [ 83, %overflowing_8 ],
+    [ 161, %basic_16 ],
+    [ 162, %basic_16_overflow_check ],
+    [ 163, %overflowing_16 ],
+    [ 321, %basic_32 ],
+    [ 322, %basic_32_overflow_check ],
+    [ 323, %overflowing_32 ],
+    [ 641, %basic_64 ],
+    [ 642, %basic_64_overflow_check ],
+    [ 643, %overflowing_64 ]
+  ret i32 %retVal
+}


### PR DESCRIPTION
* Adds tests for `uadd.with.overflow` and `sadd.with.overflow` intrinsics.
* Fixes bug where `uadd.with.overflow` wasn't calculating the overflow correctly.
* Fixes bug where headers weren't being included for generated intrinsic functions since `headerUseXXX` is being called after we've emitted the include declarations.
* Removed `maximum` and `minimum` intrinsics as these were added in #164 but weren't properly implemented.