### PR TITLE
Enable warn-as-error for MSVC, fix all warnings

### DIFF
--- a/test/c_tests/functions/test_head_recursion.c
+++ b/test/c_tests/functions/test_head_recursion.c
@@ -12,6 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// When a phi gets set to `poison` we don't initialize the PHI_TEMPORARY variable
+// so suppress "uninitialized local variable '...' used".
+// msvc_extra_args: /wd4700
+
 int head(int n) {
   if (n == 6)
     return n;

--- a/test/c_tests/functions/test_tail_recursion.c
+++ b/test/c_tests/functions/test_tail_recursion.c
@@ -12,6 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// When a phi gets set to `poison` we don't initialize the PHI_TEMPORARY variable
+// so suppress "uninitialized local variable '...' used".
+// msvc_extra_args: /wd4700
+
 int tail(int n) {
   if (n == 6)
     return n;

--- a/test/c_tests/pointers/test_char_sized_ptr_math_decr.c
+++ b/test/c_tests/pointers/test_char_sized_ptr_math_decr.c
@@ -13,6 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Suppress "array subscript -1 is outside array bounds"
+// gcc_extra_args: -Wno-array-bounds
+
 int main() {
   unsigned char inc0 = 0, inc1 = 0;
   int diff = 0, a = 100;

--- a/test/ll_tests/test_empty_array_geps.ll
+++ b/test/ll_tests/test_empty_array_geps.ll
@@ -8,6 +8,9 @@
 ;
 ; but with some simplifications.
 
+; Suppress "array is too small to include a terminating null character"
+; msvc_extra_args: /wd4295
+
 @correctStringConstant = constant [3 x i8] c"\01\02\03"
 @wrongStringConstant = constant [5 x i8] c"test\00"
 

--- a/test/ll_tests/test_gep_index_vec.ll
+++ b/test/ll_tests/test_gep_index_vec.ll
@@ -1,5 +1,8 @@
 ; This tests GEPs being indexed via vectors.
 
+; Suppress "array is too small to include a terminating null character"
+; msvc_extra_args: /wd4295
+
 @correctStringConstant = constant [3 x i8] c"\01\02\03"
 @wrongStringConstant = constant [3 x i8] c"\04\05\06"
 


### PR DESCRIPTION
* When printing a function as an operand, don't cast to `void*` in case we need to call it.
* The `BinaryNeg` should use a signed operand.
* `__faststorefence` should be called like a function.
* Use `GetValueName` when calling a function to avoid wrapping the function in an unneeded address-of.
* Added ability to suppress specific warnings for GCC and MSVC directly in the test file.