### PR TITLE
Respect the alignment attribute of functions.

### DIFF
--- a/lib/Target/CBackend/CBackend.cpp
+++ b/lib/Target/CBackend/CBackend.cpp
@@ -2053,7 +2053,8 @@ static void defineAligns(raw_ostream &Out) {
 
 static void defineFunctionAlign(raw_ostream &Out) {
   Out << "#ifdef _MSC_VER\n";
-  Out << "#define __FUNCTIONALIGN__(X) /* WARNING: THIS FEATURE IS NOT SUPPORTED BY MSVC! */ \n";
+  Out << "#define __FUNCTIONALIGN__(X) /* WARNING: THIS FEATURE IS NOT "
+         "SUPPORTED BY MSVC! */ \n";
   Out << "#else\n";
   Out << "#define __FUNCTIONALIGN__(X) __attribute__((aligned(X)))\n";
   Out << "#endif\n\n";

--- a/lib/Target/CBackend/CBackend.cpp
+++ b/lib/Target/CBackend/CBackend.cpp
@@ -2608,6 +2608,13 @@ void CWriter::generateHeader(Module &M) {
       headerUseAttributeWeak();
       Out << "__MSVC_INLINE__ ";
     }
+
+    unsigned Alignment = I->getAlignment();
+    if (Alignment != 0) {
+      headerUseAligns();
+      Out << "__PREFIXALIGN__(" << Alignment << ") ";
+    }
+
     printFunctionProto(Out, &*I, GetValueName(&*I));
     printFunctionAttributes(Out, I->getAttributes());
     if (I->hasWeakLinkage() || I->hasLinkOnceLinkage()) {
@@ -2625,6 +2632,10 @@ void CWriter::generateHeader(Module &M) {
     if (I->hasHiddenVisibility()) {
       headerUseHidden();
       Out << " __HIDDEN__";
+    }
+
+    if (Alignment != 0) {
+      Out << " __POSTFIXALIGN__(" << Alignment << ")";
     }
 
     if (I->hasName() && I->getName()[0] == 1)

--- a/lib/Target/CBackend/CBackend.h
+++ b/lib/Target/CBackend/CBackend.h
@@ -112,6 +112,7 @@ class CWriter : public FunctionPass, public InstVisitor<CWriter> {
     bool AttributeList : 1;
     bool UnalignedLoad : 1;
     bool Aligns : 1;
+    bool FunctionAlign : 1;
     bool NanInf : 1;
     bool Int128 : 1;
     bool ThreadFence : 1;
@@ -121,6 +122,7 @@ class CWriter : public FunctionPass, public InstVisitor<CWriter> {
     bool ConstantFP80Ty : 1;
     bool ConstantFP128Ty : 1;
     bool ForceInline : 1;
+    bool Trap : 1;
   } UsedHeaders;
 
 #define USED_HEADERS_FLAG(Name)                                                \
@@ -146,6 +148,7 @@ class CWriter : public FunctionPass, public InstVisitor<CWriter> {
   USED_HEADERS_FLAG(AttributeList)
   USED_HEADERS_FLAG(UnalignedLoad)
   USED_HEADERS_FLAG(Aligns)
+  USED_HEADERS_FLAG(FunctionAlign)
   USED_HEADERS_FLAG(NanInf)
   USED_HEADERS_FLAG(Int128)
   USED_HEADERS_FLAG(ThreadFence)
@@ -155,6 +158,7 @@ class CWriter : public FunctionPass, public InstVisitor<CWriter> {
   USED_HEADERS_FLAG(ConstantFP80Ty)
   USED_HEADERS_FLAG(ConstantFP128Ty)
   USED_HEADERS_FLAG(ForceInline)
+  USED_HEADERS_FLAG(Trap)
 
   llvm::SmallSet<CmpInst::Predicate, 26> FCmpOps;
   void headerUseFCmpOp(CmpInst::Predicate P);

--- a/test/cpp_tests/test_virtual_function_calls.cpp
+++ b/test/cpp_tests/test_virtual_function_calls.cpp
@@ -1,4 +1,6 @@
 #ifndef _MSC_VER
+// Suppress "dereferencing type-punned pointer will break strict-aliasing rules"
+// gcc_extra_args: -Wno-error=strict-aliasing
 struct A {
   int a;
   int b;

--- a/test/cpp_tests/test_virtual_function_calls.cpp
+++ b/test/cpp_tests/test_virtual_function_calls.cpp
@@ -1,0 +1,19 @@
+struct A {
+  int a;
+  int b;
+  int f1(int i) { return 1 + i; }
+  int f2(int i) { return 1 + i; }
+  typedef int (A::*Function)(int);
+  int function_wrapper(Function f, int i) __attribute__((noinline)) {
+    return (this->*f)(i);
+  }
+};
+
+int main() {
+  A a{};
+  if (a.function_wrapper(&A::f1, 1) != 2)
+    return 0;
+  if (a.function_wrapper(&A::f2, 1) != 2)
+    return 0;
+  return 6;
+}

--- a/test/cpp_tests/test_virtual_function_calls.cpp
+++ b/test/cpp_tests/test_virtual_function_calls.cpp
@@ -21,10 +21,9 @@ int main() {
 
 #else
 
-/* MSVC doesn't support adding alignment to functions, treat it as an expected failure */
+/* MSVC doesn't support adding alignment to functions, treat it as an expected
+ * failure */
 
-int main() {
-  return 25;
-}
+int main() { return 25; }
 
 #endif

--- a/test/cpp_tests/test_virtual_function_calls.cpp
+++ b/test/cpp_tests/test_virtual_function_calls.cpp
@@ -1,3 +1,4 @@
+#ifndef _MSC_VER
 struct A {
   int a;
   int b;
@@ -17,3 +18,13 @@ int main() {
     return 0;
   return 6;
 }
+
+#else
+
+/* MSVC doesn't support adding alignment to functions, treat it as an expected failure */
+
+int main() {
+  return 25;
+}
+
+#endif

--- a/test/cpp_tests/test_virtual_function_calls.cpp
+++ b/test/cpp_tests/test_virtual_function_calls.cpp
@@ -1,6 +1,6 @@
 #ifndef _MSC_VER
 // Suppress "dereferencing type-punned pointer will break strict-aliasing rules"
-// gcc_extra_args: -Wno-error=strict-aliasing
+// gcc_extra_args: -Wno-strict-aliasing
 struct A {
   int a;
   int b;


### PR DESCRIPTION
This is necessary to support calls to function pointer calls to member functions (which need to be aligned to 2, and the generated code crashes if this happens to be not the case)