### PR TITLE
Declare all global variables, even the local / static ones, before defining them

### DIFF
--- a/lib/Target/CBackend/CBackend.cpp
+++ b/lib/Target/CBackend/CBackend.cpp
@@ -2510,10 +2510,12 @@ void CWriter::generateHeader(Module &M) {
 
   // Global variable declarations...
   if (!M.global_empty()) {
-    Out << "\n/* External Global Variable Declarations */\n";
+    Out << "\n/* Global Variable Declarations */\n";
     for (Module::global_iterator I = M.global_begin(), E = M.global_end();
          I != E; ++I) {
-      if (!I->isDeclaration())
+      // Ignore special globals, such as debug info, and the
+      // constructors/destructors are handled in a different way
+      if (getGlobalVariableClass(&*I))
         continue;
 
       if (I->isConstant())
@@ -2527,8 +2529,8 @@ void CWriter::generateHeader(Module &M) {
       if (I->hasExternalLinkage() || I->hasExternalWeakLinkage() ||
           I->hasCommonLinkage())
         Out << "extern ";
-      else
-        continue; // Internal Global
+      else if (I->hasLocalLinkage())
+        Out << "static ";
 
       // Thread Local Storage
       if (I->isThreadLocal())

--- a/test/ll_tests/test_global_var_order.ll
+++ b/test/ll_tests/test_global_var_order.ll
@@ -1,0 +1,6 @@
+@test_array = constant { [1 x i8*] } { [1 x i8*] [i8* @defined_after_test_array] }
+@defined_after_test_array = constant i8* null
+
+define dso_local i32 @main() #0 {
+  ret i32 6
+}


### PR DESCRIPTION
This allows initializers to refer to all other global variables, regardless of when/where those are defined. Fixes #146 and #162