### PR TITLE
Generating an invert operation for boolean xor is invalid in most contexts due to integer promotion

### DIFF
--- a/lib/Target/CBackend/CBackend.cpp
+++ b/lib/Target/CBackend/CBackend.cpp
@@ -4215,10 +4215,6 @@ void CWriter::visitBinaryOperator(BinaryOperator &I) {
     Out << "-(";
     writeOperand(X);
     Out << ")";
-  } else if (match(&I, m_Not(m_Value(X)))) {
-    Out << "~(";
-    writeOperand(X);
-    Out << ")";
   } else if (I.getOpcode() == Instruction::FRem) {
     // Output a call to fmod/fmodf instead of emitting a%b
     if (I.getType() == Type::getFloatTy(I.getContext()))

--- a/test/ll_tests/test_if_bool_xor.ll
+++ b/test/ll_tests/test_if_bool_xor.ll
@@ -1,0 +1,15 @@
+define dso_local i1 @a() {
+  ret i1 1
+}
+
+define dso_local i32 @main() #0 {
+  %ret  = call zeroext i1 @a()
+  %cond = xor i1 %ret, true
+  br i1 %cond, label %a_is_false, label %a_is_true
+
+a_is_false:
+  ret i32 -1
+
+a_is_true:
+  ret i32 6
+}


### PR DESCRIPTION
The problem with generating `~(boolean_var)` for a 'not' pattern match is that, in the context of an if-statement, this results in `if (~(boolean_var))`. However, `~` promotes it to an integer. In case `boolean_var` is true, this operation thus results in a value of 111111[...]110, which evaluates to true, not false.

This isn't noticeable when the end result is immediately returned from a function as an i1 itself; but in cases where the end result is used in an if-statement it is incorrect.

By removing this pattern match, xor is just used for the code generation, which does work in this case.