### PR TITLE
Add a type cast in printGEPExpression

### DIFF
--- a/lib/Target/CBackend/CBackend.h
+++ b/lib/Target/CBackend/CBackend.h
@@ -339,7 +339,8 @@ private:
   void printBranchToBlock(BasicBlock *CurBlock, BasicBlock *SuccBlock,
                           unsigned Indent);
   void printGEPExpression(Value *Ptr, unsigned NumOperands, gep_type_iterator I,
-                          gep_type_iterator E);
+                          gep_type_iterator E,
+                          std::optional<Type *> SourceType = std::nullopt);
 
   std::string GetValueName(const Value *Operand);
 


### PR DESCRIPTION
Added a type cast to `printGEPExpression` output if the GEP type does not match the internal type.

I'm not sure if this makes sense and/or covers every edge case, but samples provided in #193 and #203 now generate C code that compiles.

May fix #193 and #203.