### PR TITLE
add clang frontend support for more reliable ABI generation

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: LLVM
+LineEnding: LF

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ __pycache__
 
 # Build folder
 build/
+llvm-project/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# LLVM-CBE Build Instructions
+
+## Install CMake (if needed)
+
+```bash
+curl -L -O https://github.com/Kitware/CMake/releases/download/v3.30.0/cmake-3.30.0-linux-x86_64.tar.gz
+tar -xzf cmake-3.30.0-linux-x86_64.tar.gz
+export PATH=$PWD/cmake-3.30.0-linux-x86_64/bin:$PATH
+```
+
+## Build LLVM (if needed)
+
+```bash
+git clone --single-branch --branch llvmorg-20.1.8 --depth 1 https://github.com/llvm/llvm-project.git
+cd llvm-project
+cmake -S llvm -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Debug -DLLVM_ENABLE_PROJECTS="clang" -DLLVM_ENABLE_ASSERTIONS=ON -DBUILD_SHARED_LIBS=ON
+ninja
+```
+
+## Run Tests
+
+### pytest
+```bash
+cd /home/vtjnash/llvm-cbe
+pip install pytest pytest-xdist
+pytest -n 4
+```
+
+### Unit tests
+```bash
+cd /home/vtjnash/llvm-project/llvm/build
+make CBEUnitTests && projects/llvm-cbe/unittests/CWriterTest
+```

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,10 +13,13 @@ if (NOT DEFINED LLVM_VERSION_MAJOR)
   include(AddLLVM)
 
   set (CMAKE_CXX_STANDARD 17)
+else()
+  set (USE_SYSTEM_LLVM 0)
 endif()
 
 add_subdirectory(lib)
 add_subdirectory(tools)
+add_subdirectory(clang-plugin)
 
 if( LLVM_INCLUDE_TESTS )
   add_subdirectory(unittests)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ llvm-cbe
 
 This LLVM C backend has been resurrected by Julia Computing with various improvements.
 
+See clang-plugin/README for an enhanced version which provides much more reliable support for linking the output against existing C libraries.
+Linking against C++ libraries (or other non-C front-ends ABIs) is not likely to be reliable,
+unless it has been defined in terms of a C ABI (such as GCC's Itanium ABI that it uses for most C++ code).
+
 Installation instructions
 =========================
 

--- a/clang-plugin/CBackend.cpp
+++ b/clang-plugin/CBackend.cpp
@@ -1,0 +1,91 @@
+//===-- CBackend.cpp - C Backend ABI Plugin ------------------------------===//
+//
+// Loadable plugin that provides a type-preserving ABI for LLVM C backend.
+// Load with: clang -Xclang -load -Xclang CBackendPlugin.so
+//
+// Triple format: llvm32-<os>[-<env>] or llvm64-<os>[-<env>]
+//   e.g. llvm32-linux-gnu, llvm64-linux-gnu, llvm64-darwin
+//
+//===----------------------------------------------------------------------===//
+
+#include "ABIInfo.h"
+#include "ABIInfoImpl.h"
+#include "TargetInfo.h"
+#include "clang/CodeGen/CGFunctionInfo.h"
+#include "llvm/Support/Compiler.h"
+#include "llvm/TargetParser/Triple.h"
+
+using namespace clang;
+using namespace clang::CodeGen;
+
+namespace {
+
+class CBackendABIInfo : public ABIInfo {
+public:
+  CBackendABIInfo(CodeGenTypes &CGT) : ABIInfo(CGT) {}
+
+  ABIArgInfo classifyReturnType(QualType RetTy) const {
+    if (RetTy->isVoidType())
+      return ABIArgInfo::getIgnore();
+    if (RetTy->isSignedIntegerOrEnumerationType())
+      return ABIArgInfo::getSignExtend(RetTy);
+    else if (RetTy->isUnsignedIntegerOrEnumerationType())
+      return ABIArgInfo::getZeroExtend(RetTy);
+    return ABIArgInfo::getDirect(nullptr, 0, nullptr, /*CanBeFlattened*/ false);
+  }
+
+  ABIArgInfo classifyArgumentType(QualType Ty) const {
+    Ty = useFirstFieldIfTransparentUnion(Ty);
+    if (Ty->isVoidType())
+      return ABIArgInfo::getIgnore();
+    if (Ty->isSignedIntegerOrEnumerationType())
+      return ABIArgInfo::getSignExtend(Ty);
+    else if (Ty->isUnsignedIntegerOrEnumerationType())
+      return ABIArgInfo::getZeroExtend(Ty);
+    if (isAggregateTypeForABI(Ty)) {
+      // Structures with either a non-trivial destructor or a non-trivial
+      // copy constructor are always indirect.
+      if (CGCXXABI::RecordArgABI RAA = getRecordArgABI(Ty, getCXXABI())) {
+        return getNaturalAlignIndirect(Ty, /*ByVal=*/RAA ==
+                                               CGCXXABI::RAA_DirectInMemory);
+      }
+    }
+    return ABIArgInfo::getDirect(nullptr, 0, nullptr, /*CanBeFlattened*/ false);
+  }
+
+  void computeInfo(CGFunctionInfo &FI) const override {
+    if (!::classifyReturnType(getCXXABI(), FI, *this))
+      FI.getReturnInfo() = classifyReturnType(FI.getReturnType());
+    for (auto &Arg : FI.arguments())
+      Arg.info = classifyArgumentType(Arg.type);
+  }
+
+  RValue EmitVAArg(CodeGenFunction &CGF, Address VAListAddr, QualType Ty,
+                   AggValueSlot Slot) const override {
+    return emitVoidPtrVAArg(CGF, VAListAddr, Ty, /*IsIndirect=*/false,
+                            CGF.getContext().getTypeInfoInChars(Ty),
+                            CharUnits::fromQuantity(8),
+                            /*AllowHigherAlign=*/true, Slot);
+  }
+};
+
+class CBackendTargetCodeGenInfo : public TargetCodeGenInfo {
+public:
+  CBackendTargetCodeGenInfo(CodeGenTypes &CGT)
+      : TargetCodeGenInfo(std::make_unique<CBackendABIInfo>(CGT)) {}
+};
+} // namespace
+
+namespace clang {
+namespace CodeGen {
+inline std::unique_ptr<TargetCodeGenInfo>
+createCBackendTargetCodeGenInfo(CodeGenModule &CGM) {
+  return std::make_unique<CBackendTargetCodeGenInfo>(CGM.getTypes());
+}
+} // namespace CodeGen
+} // namespace clang
+
+extern "C" LLVM_ABI_EXPORT void *getCBackendABIForTarget(const llvm::Triple *T,
+                                                         CodeGenModule *CGM) {
+  return createCBackendTargetCodeGenInfo(*CGM).release();
+}

--- a/clang-plugin/CMakeLists.txt
+++ b/clang-plugin/CMakeLists.txt
@@ -1,0 +1,35 @@
+IF (NOT DEFINED LLVM_VERSION_MAJOR)
+  # Standalone build: requires both LLVM and Clang CMake packages
+  project(CBackendPlugin)
+  cmake_minimum_required(VERSION 3.20.0)
+  find_package(LLVM 20.1 REQUIRED CONFIG)
+  find_package(Clang REQUIRED CONFIG)
+  list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
+  include(AddLLVM)
+  set(CMAKE_CXX_STANDARD 17)
+  include_directories(${LLVM_INCLUDE_DIRS} ${CLANG_INCLUDE_DIRS})
+  add_definitions(${LLVM_DEFINITIONS})
+else()
+  find_package(Clang REQUIRED CONFIG)
+  include_directories(${CLANG_INCLUDE_DIRS})
+endif()
+
+# Internal Clang CodeGen headers (ABIInfo.h, TargetInfo.h, etc.) are not
+# exported; derive path from the LLVM source include directory.
+get_filename_component(_llvm_src "${LLVM_MAIN_INCLUDE_DIR}" DIRECTORY)
+include_directories(${_llvm_src}/../clang/lib/CodeGen)
+
+add_llvm_library(CBackendPlugin MODULE
+  CBackend.cpp
+
+  LINK_LIBS
+  clangAST
+  clangBasic
+  clangCodeGen
+  LLVMSupport
+)
+
+# Plugins must not have undefined symbols
+set_target_properties(CBackendPlugin PROPERTIES
+  CXX_VISIBILITY_PRESET hidden
+)

--- a/clang-plugin/CodeGenModule.patch
+++ b/clang-plugin/CodeGenModule.patch
@@ -1,0 +1,225 @@
+diff --git a/clang/lib/Basic/Targets.cpp b/clang/lib/Basic/Targets.cpp
+index 281aebdb1..fc9274302 100644
+--- a/clang/lib/Basic/Targets.cpp
++++ b/clang/lib/Basic/Targets.cpp
+@@ -109,6 +109,42 @@ void addCygMingDefines(const LangOptions &Opts, MacroBuilder &Builder) {
+ // Driver code
+ //===----------------------------------------------------------------------===//
+ 
++namespace {
++class CBackendTargetInfo : public TargetInfo {
++public:
++  CBackendTargetInfo(const llvm::Triple &Triple, const TargetOptions &)
++      : TargetInfo(Triple) {
++    bool Is64 = Triple.isArch64Bit();
++    bool IsWindows = Triple.isOSWindows();
++    IntWidth = IntAlign = 32;
++    PointerWidth = PointerAlign = Is64 ? 64 : 32;
++    LongWidth = LongAlign = IsWindows ? 32 : PointerWidth;
++    LongLongWidth = LongLongAlign = 64;
++    SizeType = Is64 && IsWindows ? UnsignedLongLong : UnsignedLong;
++    PtrDiffType = Is64 && IsWindows ? SignedLongLong : SignedLong;
++    IntPtrType = Is64 && IsWindows ? SignedLongLong : SignedLong;
++    if (Is64)
++      resetDataLayout("e-m:e-p:64:64-i64:64-i128:128-n32:64-S128");
++    else
++      resetDataLayout("e-m:e-p:32:32-i64:64-i128:128-n32:64-S128");
++  }
++  void getTargetDefines(const LangOptions &, MacroBuilder &) const override {}
++  ArrayRef<Builtin::Info> getTargetBuiltins() const override { return {}; }
++  BuiltinVaListKind getBuiltinVaListKind() const override {
++    return TargetInfo::VoidPtrBuiltinVaList;
++  }
++  ArrayRef<const char *> getGCCRegNames() const override { return {}; }
++  ArrayRef<TargetInfo::GCCRegAlias> getGCCRegAliases() const override {
++    return {};
++  }
++  bool validateAsmConstraint(const char *&,
++                             TargetInfo::ConstraintInfo &) const override {
++    return false;
++  }
++  std::string_view getClobbers() const override { return ""; }
++};
++} // namespace
++
+ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
+                                            const TargetOptions &Opts) {
+   llvm::Triple::OSType os = Triple.getOS();
+@@ -117,6 +153,10 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
+   default:
+     return nullptr;
+ 
++  case llvm::Triple::llvm32:
++  case llvm::Triple::llvm64:
++    return std::make_unique<CBackendTargetInfo>(Triple, Opts);
++
+   case llvm::Triple::arc:
+     return std::make_unique<ARCTargetInfo>(Triple, Opts);
+ 
+diff --git a/clang/lib/CodeGen/CodeGenModule.cpp b/clang/lib/CodeGen/CodeGenModule.cpp
+index eb8d3ceee..3b65b055c 100644
+--- a/clang/lib/CodeGen/CodeGenModule.cpp
++++ b/clang/lib/CodeGen/CodeGenModule.cpp
+@@ -68,6 +68,7 @@
+ #include "llvm/Support/ErrorHandling.h"
+ #include "llvm/Support/TimeProfiler.h"
+ #include "llvm/Support/xxhash.h"
++#include "llvm/Support/DynamicLibrary.h"
+ #include "llvm/TargetParser/RISCVISAInfo.h"
+ #include "llvm/TargetParser/Triple.h"
+ #include "llvm/TargetParser/X86TargetParser.h"
+@@ -110,6 +111,13 @@ createTargetCodeGenInfo(CodeGenModule &CGM) {
+   const llvm::Triple &Triple = Target.getTriple();
+   const CodeGenOptions &CodeGenOpts = CGM.getCodeGenOpts();
+ 
++  using GetABIFn =
++      TargetCodeGenInfo *(*)(const llvm::Triple *, CodeGenModule *);
++  if (auto Fn = (GetABIFn)llvm::sys::DynamicLibrary::SearchForAddressOfSymbol(
++          "getCBackendABIForTarget"))
++    if (auto ABI = Fn(&Triple, &CGM))
++      return std::unique_ptr<TargetCodeGenInfo>(ABI);
++
+   switch (Triple.getArch()) {
+   default:
+     return createDefaultTargetCodeGenInfo(CGM);
+@@ -326,8 +334,9 @@ createTargetCodeGenInfo(CodeGenModule &CGM) {
+ }
+ 
+ const TargetCodeGenInfo &CodeGenModule::getTargetCodeGenInfo() {
+-  if (!TheTargetCodeGenInfo)
++  if (!TheTargetCodeGenInfo) {
+     TheTargetCodeGenInfo = createTargetCodeGenInfo(*this);
++  }
+   return *TheTargetCodeGenInfo;
+ }
+ 
+diff --git a/llvm/include/llvm/TargetParser/Triple.h b/llvm/include/llvm/TargetParser/Triple.h
+index 7d67966d1..7a05ab959 100644
+--- a/llvm/include/llvm/TargetParser/Triple.h
++++ b/llvm/include/llvm/TargetParser/Triple.h
+@@ -105,7 +105,9 @@ public:
+     renderscript32, // 32-bit RenderScript
+     renderscript64, // 64-bit RenderScript
+     ve,             // NEC SX-Aurora Vector Engine
+-    LastArchType = ve
++    llvm32,         // LLVM C backend 32-bit
++    llvm64,         // LLVM C backend 64-bit
++    LastArchType = llvm64
+   };
+   enum SubArchType {
+     NoSubArch,
+diff --git a/llvm/lib/TargetParser/Triple.cpp b/llvm/lib/TargetParser/Triple.cpp
+index e9e6f130f..e7ffb189f 100644
+--- a/llvm/lib/TargetParser/Triple.cpp
++++ b/llvm/lib/TargetParser/Triple.cpp
+@@ -84,6 +84,8 @@ StringRef Triple::getArchTypeName(ArchType Kind) {
+   case x86_64:         return "x86_64";
+   case xcore:          return "xcore";
+   case xtensa:         return "xtensa";
++  case llvm32:         return "llvm32";
++  case llvm64:         return "llvm64";
+   }
+ 
+   llvm_unreachable("Invalid ArchType!");
+@@ -240,6 +242,8 @@ StringRef Triple::getArchTypePrefix(ArchType Kind) {
+   case riscv64:     return "riscv";
+ 
+   case ve:          return "ve";
++  case llvm32:      return "llvm";
++  case llvm64:      return "llvm";
+   case csky:        return "csky";
+ 
+   case loongarch32:
+@@ -486,6 +490,8 @@ Triple::ArchType Triple::getArchTypeForLLVMName(StringRef Name) {
+     .Case("loongarch64", loongarch64)
+     .Case("dxil", dxil)
+     .Case("xtensa", xtensa)
++    .Case("llvm32", llvm32)
++    .Case("llvm64", llvm64)
+     .Default(UnknownArch);
+ }
+ 
+@@ -632,6 +638,8 @@ static Triple::ArchType parseArch(StringRef ArchName) {
+                  "dxilv1.4", "dxilv1.5", "dxilv1.6", "dxilv1.7", "dxilv1.8",
+                  Triple::dxil)
+           .Case("xtensa", Triple::xtensa)
++          .Case("llvm32", Triple::llvm32)
++          .Case("llvm64", Triple::llvm64)
+           .Default(Triple::UnknownArch);
+ 
+   // Some architectures require special parsing logic just to compute the
+@@ -971,6 +979,8 @@ static Triple::ObjectFormatType getDefaultFormat(const Triple &T) {
+   case Triple::tcele:
+   case Triple::thumbeb:
+   case Triple::ve:
++  case Triple::llvm32:
++  case Triple::llvm64:
+   case Triple::xcore:
+   case Triple::xtensa:
+     return Triple::ELF;
+@@ -1679,6 +1689,7 @@ unsigned Triple::getArchPointerBitWidth(llvm::Triple::ArchType Arch) {
+   case llvm::Triple::thumbeb:
+   case llvm::Triple::wasm32:
+   case llvm::Triple::x86:
++  case llvm::Triple::llvm32:
+   case llvm::Triple::xcore:
+   case llvm::Triple::xtensa:
+     return 32;
+@@ -1704,6 +1715,7 @@ unsigned Triple::getArchPointerBitWidth(llvm::Triple::ArchType Arch) {
+   case llvm::Triple::spirv64:
+   case llvm::Triple::systemz:
+   case llvm::Triple::ve:
++  case llvm::Triple::llvm64:
+   case llvm::Triple::wasm64:
+   case llvm::Triple::x86_64:
+     return 64;
+@@ -1789,6 +1801,7 @@ Triple Triple::get32BitArchVariant() const {
+   case Triple::thumbeb:
+   case Triple::wasm32:
+   case Triple::x86:
++  case Triple::llvm32:
+   case Triple::xcore:
+   case Triple::xtensa:
+     // Already 32-bit.
+@@ -1818,6 +1831,7 @@ Triple Triple::get32BitArchVariant() const {
+     break;
+   case Triple::wasm64:         T.setArch(Triple::wasm32);  break;
+   case Triple::x86_64:         T.setArch(Triple::x86);     break;
++  case Triple::llvm64:         T.setArch(Triple::llvm32);  break;
+   }
+   return T;
+ }
+@@ -1865,6 +1879,7 @@ Triple Triple::get64BitArchVariant() const {
+   case Triple::spirv64:
+   case Triple::systemz:
+   case Triple::ve:
++  case Triple::llvm64:
+   case Triple::wasm64:
+   case Triple::x86_64:
+     // Already 64-bit.
+@@ -1897,6 +1912,7 @@ Triple Triple::get64BitArchVariant() const {
+   case Triple::thumbeb:         T.setArch(Triple::aarch64_be); break;
+   case Triple::wasm32:          T.setArch(Triple::wasm64);     break;
+   case Triple::x86:             T.setArch(Triple::x86_64);     break;
++  case Triple::llvm32:          T.setArch(Triple::llvm64);     break;
+   }
+   return T;
+ }
+@@ -1939,6 +1955,8 @@ Triple Triple::getBigEndianArchVariant() const {
+   case Triple::x86_64:
+   case Triple::xcore:
+   case Triple::ve:
++  case Triple::llvm32:
++  case Triple::llvm64:
+   case Triple::csky:
+   case Triple::xtensa:
+ 
+@@ -2044,6 +2062,8 @@ bool Triple::isLittleEndian() const {
+   case Triple::tcele:
+   case Triple::thumb:
+   case Triple::ve:
++  case Triple::llvm32:
++  case Triple::llvm64:
+   case Triple::wasm32:
+   case Triple::wasm64:
+   case Triple::x86:

--- a/clang-plugin/README.md
+++ b/clang-plugin/README.md
@@ -1,0 +1,77 @@
+# C Backend Clang Target
+
+A Clang plugin that preserves type information in LLVM IR for more accurate C code generation with llvm-cbe.
+
+## Problem
+
+LLVM IR doesn't preserve integer signedness. When llvm-cbe converts IR back to C, it can't distinguish `int` from `unsigned int`, causing incorrect function signatures and compiler warnings.
+
+**Before:**
+```llvm
+define i32 @add(i32 %a, i32 %b)  ; No signedness info!
+```
+**After (with this plugin):**
+```llvm
+define i32 @add(i32 signext %a, i32 zeroext %b)  ; Signedness preserved!
+```
+
+## Setup
+
+### 1. Build plugin
+
+**In-tree** (when llvm-cbe is symlinked into `llvm/projects/`):
+```bash
+ninja -C /path/to/llvm/build CBackendPlugin
+```
+
+**Standalone**:
+```bash
+cmake -S clang-plugin -B clang-plugin/build \
+      -DLLVM_DIR=/path/to/llvm/build/lib/cmake/llvm \
+      -DClang_DIR=/path/to/llvm/build/lib/cmake/clang
+cmake --build clang-plugin/build
+# Creates: clang-plugin/build/CBackendPlugin.so
+```
+
+### 2. Patch Clang
+
+```bash
+cd /path/to/llvm-project
+patch -p1 < /path/to/clang-plugin/CodeGenModule.patch
+ninja -C build
+```
+
+The patch adds a hook to `CodeGenModule::getTargetCodeGenInfo()` that calls `getCBackendABIForTarget` via `DynamicLibrary::SearchForAddressOfSymbol` when the plugin is loaded.
+
+## Usage
+
+```bash
+clang -fplugin ./build/CBackendPlugin.so \
+      -target llvm64-linux-gnu \
+      -S -emit-llvm input.c -o output.ll
+
+llvm-cbe output.ll -o output.cbe.c
+```
+
+## How It Works
+
+`CodeGenModule::getTargetCodeGenInfo()` checks via `dlsym` whether `getCBackendABIForTarget` is present. If the plugin is loaded and the target triple has arch `llvm32` or `llvm64`, it returns a custom `TargetCodeGenInfo` that:
+
+- Marks signed integers with `signext`
+- Marks unsigned integers with `zeroext`
+- Returns structs directly (no `sret`)
+- Passes structs directly (no `byval`)
+
+## Target Triple Examples
+
+This doesn't need to exactly match the target environment, but the closer you get, the more likely the ABI will get translated correctly. In particular, 32 vs. 64 pointer size, endianness (currently unsupported), and C++ ABI (OS) are the most likely to be impactful, in that order.
+
+Format: `llvm32-<os>[-<env>]` or `llvm64-<os>[-<env>]`
+
+| Triple | Description |
+|--------|-------------|
+| `llvm32-linux-gnu` | Linux (glibc) 32-bit |
+| `llvm64-linux-gnu` | Linux (glibc) 64-bit |
+| `llvm64-darwin` | macOS 64-bit |
+| `llvm32-windows-msvc` | Windows (MSVC) 32-bit |
+| `llvm64-windows-msvc` | Windows (MSVC) 64-bit |

--- a/test/clang-plugin/test-example.c
+++ b/test/clang-plugin/test-example.c
@@ -1,0 +1,67 @@
+// Test file for C Backend target
+// This demonstrates the type preservation features
+
+#include <stdint.h>
+
+// Test 1: Integer signedness preservation
+int32_t signed_add(int32_t a, int32_t b) { return a + b; }
+
+uint32_t unsigned_add(uint32_t a, uint32_t b) { return a + b; }
+
+// Test 2: Mixed signedness
+int32_t mixed_operation(int32_t signed_val, uint32_t unsigned_val) {
+  return signed_val + unsigned_val;
+}
+
+// Test 3: Structure return (should not use sret)
+struct Point {
+  int x;
+  int y;
+};
+
+struct Point make_point(int x, int y) {
+  struct Point p;
+  p.x = x;
+  p.y = y;
+  return p;
+}
+
+// Test 4: Structure argument (should not use byval)
+int point_sum(struct Point p) { return p.x + p.y; }
+
+// Test 5: Large structure (should still avoid sret/byval)
+struct LargeStruct {
+  int64_t data[8];
+};
+
+struct LargeStruct make_large(int64_t val) {
+  struct LargeStruct s;
+  for (int i = 0; i < 8; i++) {
+    s.data[i] = val * i;
+  }
+  return s;
+}
+
+// Test 6: Enum types (preserve underlying signedness)
+enum Color { RED = 0, GREEN = 1, BLUE = 2 };
+
+enum Color get_color(int value) { return (enum Color)value; }
+
+// Test 7: Character types (char should be signed, unsigned char should be
+// unsigned)
+char signed_char_func(char c) { return c + 1; }
+
+unsigned char unsigned_char_func(unsigned char c) { return c + 1; }
+
+// Test 8: Short types
+short signed_short_func(short s) { return s * 2; }
+
+unsigned short unsigned_short_func(unsigned short s) { return s * 2; }
+
+// Test 9: Long types
+long signed_long_func(long l) { return l - 1; }
+
+unsigned long unsigned_long_func(unsigned long l) { return l - 1; }
+
+// Test 10: Boolean type
+_Bool bool_func(_Bool b) { return !b; }


### PR DESCRIPTION
This helps to generate correct function signatures in many more cases, by preserving the information from the clang C/C++ front-end about the sign and struct layout of the original arguments, other than any alignment differences of the individual members. If trying to use this for another language frontend (e.g. rust, julia, flang), they would require a similar plug-in to preserve the ABI information similarly.

Fixes: https://github.com/JuliaHubOSS/llvm-cbe/issues/98